### PR TITLE
Update to remove Pedro misinformation

### DIFF
--- a/src/misc/pedro_vs_roadrunner.md
+++ b/src/misc/pedro_vs_roadrunner.md
@@ -1,24 +1,28 @@
 # Pedro Pathing vs Road Runner
 
-**Pedro Pathing** is a recently-created library for autonomous.  
-It uses a GVF algorithm utilizing Bézier Curves to follow trajectories with speed as a top priority.  
+**Pedro Pathing** is a path following library.  
+It’s a reactive vector follower that implements translational, heading, and centripetal force correction to dynamically converge to the target position.  
 
+**Links:**
 - Docs: https://pedropathing.com
 - Quickstart: https://github.com/Pedro-Pathing/Quickstart
+- Library: https://github.com/Pedro-Pathing/PedroPathing
 
-**Pros of Pedro** 
+**Pros of Pedro:** 
 - Can make your bot drive faster.  
-- Support for recent sensors (OTOS, Pinpoint) is official/built-in.  
+- Support for recent sensors (OTOS, Pinpoint) are official/built-in.  
 - Excellent correction for unexpected disturbances.
 - Has a no-code, browser-based path visualizer
+- Pedro can be paired efficently with command-based libraries, as it runs fully async.
+- Can be added to TeleOp in 3 lines - allows for on the fly automations and macros with driving
 
 **Cons of Pedro:**
+- Newer, so potentially buggier.
+- Less people use it compared to Road Runner.
+- Not necessarily time-consistent, as it may spend time correcting for external disturbances.
+- Visualizer uses a nonstandard coordinate scheme, but Poses can be easily converted to the FTC Standard via a class method
 
-- Newer, so potentially less stable/buggier.
-- Fewer people are familiar with it and able to help.
-- Not necessarily time-consistent.
-- Visualizer uses a nonstandard coordinate scheme, complicating AprilTag integration.
-- Does not compensate for battery voltage differences, meaning worse consistency
+---
 
 **Road Runner** is a motion-profiling-based follower library
 that includes a command-based action system and geometry. 
@@ -28,25 +32,19 @@ with version 1.0 created mid-2023 and last updated 10/13.
 
 It prioritizes time consistency above all else.
 
-Library Repo: <https://github.com/acmerobotics/road-runner/>
-
-Quickstart: <https://github.com/acmerobotics/road-runner-quickstart/tree/master/>
-
-Official Docs: <https://rr.brott.dev/docs/v1-0/installation/>
-
+- Library Repo: <https://github.com/acmerobotics/road-runner/>
+- Quickstart: <https://github.com/acmerobotics/road-runner-quickstart/tree/master/>
+- Official Docs: <https://rr.brott.dev/docs/v1-0/installation/>
 
 **Pros of Road Runner:**
-
 - Stable, minimal bugs if any
 - Time consistent by default
 - Extensively tested. It's used by thousands of teams that are able to help you in the FTC Discord, 
 and someone has almost certainly had your problem before.
 - Lots of projects integrate with it
 - Uses the FIRST-recommended standard coordinate system consistently
-- Compensates for battery voltage differences to maximize auto consistency
 
 **Cons of Roadrunner:**
-
 - Prioritizes time consistency above all else, meaning potentially worse correction
 - Slower speed by default
 - Support for recent sensors like the SparkFun OTOS and Pinpoint is unofficial
@@ -54,4 +52,4 @@ and someone has almost certainly had your problem before.
 - Path visualizer is code based
 
 
-*Last Updated: 2025-1-5*
+*Last Updated: 2025-2-16*   


### PR DESCRIPTION
Remove the voltage comp. as both libraries do it. Pedro is not a gvf. Add mention to command frameworks as RR does. Add mention to be able to easily translate to and from FTC Standard Coord system. Add Teleop usage comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the description of the path-following library for improved understanding.
  - Added new resource links, including documentation and quickstart guides.
  - Expanded benefits and refined drawbacks for clearer comparisons.
  - Updated the "Road Runner" section with a recent update date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->